### PR TITLE
feat: create part model and add book#index as root

### DIFF
--- a/app/controllers/parts_controller.rb
+++ b/app/controllers/parts_controller.rb
@@ -1,0 +1,70 @@
+class PartsController < ApplicationController
+  before_action :set_part, only: %i[ show edit update destroy ]
+
+  # GET /parts or /parts.json
+  def index
+    @parts = Part.all
+  end
+
+  # GET /parts/1 or /parts/1.json
+  def show
+  end
+
+  # GET /parts/new
+  def new
+    @part = Part.new
+  end
+
+  # GET /parts/1/edit
+  def edit
+  end
+
+  # POST /parts or /parts.json
+  def create
+    @part = Part.new(part_params)
+
+    respond_to do |format|
+      if @part.save
+        format.html { redirect_to part_url(@part), notice: "Part was successfully created." }
+        format.json { render :show, status: :created, location: @part }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @part.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /parts/1 or /parts/1.json
+  def update
+    respond_to do |format|
+      if @part.update(part_params)
+        format.html { redirect_to part_url(@part), notice: "Part was successfully updated." }
+        format.json { render :show, status: :ok, location: @part }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @part.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /parts/1 or /parts/1.json
+  def destroy
+    @part.destroy!
+
+    respond_to do |format|
+      format.html { redirect_to parts_url, notice: "Part was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_part
+      @part = Part.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def part_params
+      params.require(:part).permit(:name, :supplier_id)
+    end
+end

--- a/app/helpers/parts_helper.rb
+++ b/app/helpers/parts_helper.rb
@@ -1,0 +1,2 @@
+module PartsHelper
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,3 +1,3 @@
-class Account < ApplicationRecord
+class Account < ApplicationRecord  
   belongs_to :supplier
 end

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -1,0 +1,3 @@
+class Part < ApplicationRecord
+  belongs_to :supplier
+end

--- a/app/views/parts/_form.html.erb
+++ b/app/views/parts/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: part) do |form| %>
+  <% if part.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(part.errors.count, "error") %> prohibited this part from being saved:</h2>
+
+      <ul>
+        <% part.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name, style: "display: block" %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.label :supplier_id, style: "display: block" %>
+    <%= form.collection_select :supplier_id, Supplier.all, :id, :name, prompt: 'Select Supplier'%>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/parts/_part.html.erb
+++ b/app/views/parts/_part.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id part %>">
+  <p>
+    <strong>Name:</strong>
+    <%= part.name %>
+  </p>
+
+  <p>
+    <strong>Supplier:</strong>
+    <%= part.supplier_id %>
+  </p>
+
+</div>

--- a/app/views/parts/_part.json.jbuilder
+++ b/app/views/parts/_part.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! part, :id, :name, :supplier_id, :created_at, :updated_at
+json.url part_url(part, format: :json)

--- a/app/views/parts/edit.html.erb
+++ b/app/views/parts/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing part</h1>
+
+<%= render "form", part: @part %>
+
+<br>
+
+<div>
+  <%= link_to "Show this part", @part %> |
+  <%= link_to "Back to parts", parts_path %>
+</div>

--- a/app/views/parts/index.html.erb
+++ b/app/views/parts/index.html.erb
@@ -1,0 +1,14 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>Parts</h1>
+
+<div id="parts">
+  <% @parts.each do |part| %>
+    <%= render part %>
+    <p>
+      <%= link_to "Show this part", part %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New part", new_part_path %>

--- a/app/views/parts/index.json.jbuilder
+++ b/app/views/parts/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @parts, partial: "parts/part", as: :part

--- a/app/views/parts/new.html.erb
+++ b/app/views/parts/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New part</h1>
+
+<%= render "form", part: @part %>
+
+<br>
+
+<div>
+  <%= link_to "Back to parts", parts_path %>
+</div>

--- a/app/views/parts/show.html.erb
+++ b/app/views/parts/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @part %>
+
+<div>
+  <%= link_to "Edit this part", edit_part_path(@part) %> |
+  <%= link_to "Back to parts", parts_path %>
+
+  <%= button_to "Destroy this part", @part, method: :delete %>
+</div>

--- a/app/views/parts/show.json.jbuilder
+++ b/app/views/parts/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "parts/part", part: @part

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -18,5 +18,9 @@
     <%= link_to "Accounts", accounts_path %>
   </div>
   
+  <div class="Parts" style="padding: 10px">
+    <%= link_to "Parts", parts_path %>
+  </div>
+
   <div class="Navbar__Link" style="padding: 10px">-- Link --</div>  
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :parts
   resources :accounts
   resources :suppliers
   resources :books
@@ -10,5 +11,5 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
-  # root "posts#index"
+   root "books#index"
 end

--- a/db/migrate/20240209232605_create_parts.rb
+++ b/db/migrate/20240209232605_create_parts.rb
@@ -1,0 +1,10 @@
+class CreateParts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :parts do |t|
+      t.string :name
+      t.references :supplier, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_185401) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_09_232605) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "account_number"
     t.bigint "supplier_id", null: false
@@ -34,6 +34,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_185401) do
     t.index ["author_id"], name: "index_books_on_author_id"
   end
 
+  create_table "parts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.bigint "supplier_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["supplier_id"], name: "index_parts_on_supplier_id"
+  end
+
   create_table "suppliers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -42,4 +50,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_185401) do
 
   add_foreign_key "accounts", "suppliers"
   add_foreign_key "books", "authors"
+  add_foreign_key "parts", "suppliers"
 end

--- a/test/controllers/parts_controller_test.rb
+++ b/test/controllers/parts_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class PartsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @part = parts(:one)
+  end
+
+  test "should get index" do
+    get parts_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_part_url
+    assert_response :success
+  end
+
+  test "should create part" do
+    assert_difference("Part.count") do
+      post parts_url, params: { part: { name: @part.name, supplier_id: @part.supplier_id } }
+    end
+
+    assert_redirected_to part_url(Part.last)
+  end
+
+  test "should show part" do
+    get part_url(@part)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_part_url(@part)
+    assert_response :success
+  end
+
+  test "should update part" do
+    patch part_url(@part), params: { part: { name: @part.name, supplier_id: @part.supplier_id } }
+    assert_redirected_to part_url(@part)
+  end
+
+  test "should destroy part" do
+    assert_difference("Part.count", -1) do
+      delete part_url(@part)
+    end
+
+    assert_redirected_to parts_url
+  end
+end

--- a/test/fixtures/parts.yml
+++ b/test/fixtures/parts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  supplier: one
+
+two:
+  name: MyString
+  supplier: two

--- a/test/models/part_test.rb
+++ b/test/models/part_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PartTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/parts_test.rb
+++ b/test/system/parts_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class PartsTest < ApplicationSystemTestCase
+  setup do
+    @part = parts(:one)
+  end
+
+  test "visiting the index" do
+    visit parts_url
+    assert_selector "h1", text: "Parts"
+  end
+
+  test "should create part" do
+    visit parts_url
+    click_on "New part"
+
+    fill_in "Name", with: @part.name
+    fill_in "Supplier", with: @part.supplier_id
+    click_on "Create Part"
+
+    assert_text "Part was successfully created"
+    click_on "Back"
+  end
+
+  test "should update Part" do
+    visit part_url(@part)
+    click_on "Edit this part", match: :first
+
+    fill_in "Name", with: @part.name
+    fill_in "Supplier", with: @part.supplier_id
+    click_on "Update Part"
+
+    assert_text "Part was successfully updated"
+    click_on "Back"
+  end
+
+  test "should destroy Part" do
+    visit part_url(@part)
+    click_on "Destroy this part", match: :first
+
+    assert_text "Part was successfully destroyed"
+  end
+end


### PR DESCRIPTION

### Create the entity
`rails g scaffold Part name supplier:references`

### Migrate database
`rails db:migrate`

### Insert the link in navbar
Added the following lines to do this:

```ruby
<div class="Parts" style="padding: 10px">
    <%= link_to "Parts", parts_path %>
</div>
``` 

### Change the view archive to show the other related entity.  

In the file: app/views/parts/_form.html.erb

```ruby
  <div>
    <%= form.label :supplier_id, style: "display: block" %>
    <%= form.collection_select :supplier_id, Supplier.all, :id, :name, prompt: 'Select Supplier'%>
  </div>
``` 
This will show the name of the supplier to choose instead of only the id.