### PR TITLE
feat: Add field CNPJ in Supplier

### DIFF
--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -65,6 +65,6 @@ class SuppliersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def supplier_params
-      params.require(:supplier).permit(:name)
+      params.require(:supplier).permit(:name, :cnpj)
     end
 end

--- a/app/views/suppliers/_form.html.erb
+++ b/app/views/suppliers/_form.html.erb
@@ -17,6 +17,11 @@
   </div>
 
   <div>
+    <%= form.label :CNPJ, style: "display: block" %>
+    <%= form.text_field :cnpj %>
+  </div>
+
+  <div>
     <%= form.submit %>
   </div>
 <% end %>

--- a/db/migrate/20240211161726_add_cnpj_to_suppliers.rb
+++ b/db/migrate/20240211161726_add_cnpj_to_suppliers.rb
@@ -1,0 +1,5 @@
+class AddCnpjToSuppliers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :suppliers, :cnpj, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_10_110003) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_11_161726) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "account_number"
     t.bigint "supplier_id", null: false
@@ -62,6 +62,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_110003) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "cnpj"
   end
 
   add_foreign_key "accounts", "suppliers"


### PR DESCRIPTION
### Add CNPJ to Supplier:
`rails g migration AddCnpjToSuppliers cnpj:string`

### Migrate database.
`rails db:migrate`

### Insert CNPJ field in the supplier form:
In the file: app/views/suppliers/_form.html.erb
```ruby
  <div>
     <%= form.label :CNPJ, style: "display: block" %>
     <%= form.text_field :cnpj %>
  </div>
``` 

### Allow the controller to receive CNPJ param.
In the file app/controllers/suppliers_controller.rb
```ruby
...
    # Only allow a list of trusted parameters through.
    def supplier_params
      params.require(:supplier).permit(:name, :cnpj)
    end
...
``` 