### PR TITLE
feat: Add field CPF in Author

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -65,6 +65,6 @@ class AuthorsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def author_params
-      params.require(:author).permit(:name)
+      params.require(:author).permit(:name, :cpf)
     end
 end

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -17,6 +17,11 @@
   </div>
 
   <div>
+    <%= form.label :cpf, style: "display: block" %>
+    <%= form.text_field :cpf %>
+ </div>
+
+  <div>
     <%= form.submit %>
   </div>
 <% end %>

--- a/db/migrate/20240211164954_add_cpf_to_authors.rb
+++ b/db/migrate/20240211164954_add_cpf_to_authors.rb
@@ -1,0 +1,5 @@
+class AddCpfToAuthors < ActiveRecord::Migration[7.1]
+  def change
+    add_column :authors, :cpf, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_11_161726) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_11_164954) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "account_number"
     t.bigint "supplier_id", null: false
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_11_161726) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "cpf"
   end
 
   create_table "books", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
### Add CPF to Author:
`rails g migration AddCpfToAuthors cpf:string`

### Migrate database.
`rails db:migrate`

### Insert CPF field in the author form:
In the file: app/views/authors/_form.html.erb
```ruby
  <div>
     <%= form.label :cpf, style: "display: block" %>
     <%= form.text_field :cpf %>
  </div>
``` 

### Allow the controller to receive CPF param.
In the file app/controllers/authors_controller.rb
```ruby
...
    # Only allow a list of trusted parameters through.
    def author_params
      params.require(:author).permit(:name, :cpf)
    end
...
``` 