### PR TITLE
feat: Add field ISBN in Book

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -65,6 +65,6 @@ class BooksController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def book_params
-      params.require(:book).permit(:name, :description, :author_id, assembly_ids: [])
+      params.require(:book).permit(:name, :description, :author_id, :isbn, assembly_ids: [])
     end
 end

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -39,6 +39,11 @@
   </div>
 
   <div>
+    <%= form.label :isbn, style: "display: block" %>
+    <%= form.text_field :isbn %>
+  </div>
+
+  <div>
     <%= form.submit %>
   </div>
 <% end %>

--- a/db/migrate/20240211170643_add_isbn_to_books.rb
+++ b/db/migrate/20240211170643_add_isbn_to_books.rb
@@ -1,0 +1,5 @@
+class AddIsbnToBooks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :books, :isbn, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_11_164954) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_11_170643) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "account_number"
     t.bigint "supplier_id", null: false
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_11_164954) do
     t.bigint "author_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "isbn"
     t.index ["author_id"], name: "index_books_on_author_id"
   end
 


### PR DESCRIPTION
### Add ISBN to Book:
`rails g migration AddIsbnToBooks isbn:string`

### Migrate database.
`rails db:migrate`

### Insert ISBN field in the author form:
In the file: app/views/books/_form.html.erb
```ruby
...
   <div>
      <%= form.label :isbn, style: "display: block" %>
      <%= form.text_field :isbn %>
  </div>
...
``` 

### Allow the controller to receive ISBN param.
In the file 
```ruby
...
    # Only allow a list of trusted parameters through.
    def book_params
      params.require(:book).permit(:name, :description, :author_id, :isbn, assembly_ids: [])
    end
...
``` 