### PR TITLE
feat: Add field Verify digit in Account

### DIFF
--- a/db/migrate/20240211173135_add_verify_digit_to_accounts.rb
+++ b/db/migrate/20240211173135_add_verify_digit_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddVerifyDigitToAccounts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :accounts, :verify_digit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_11_170643) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_11_173135) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "account_number"
     t.bigint "supplier_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "verify_digit"
     t.index ["supplier_id"], name: "index_accounts_on_supplier_id"
   end
 


### PR DESCRIPTION
### Add Verify digit to Account:
`rails g migration AddVerify_digitToAccounts verify_digit:string`

### Migrate database.
`rails db:migrate`

### Insert Verify digit field in the account form and Allow the controller to receive ISBN param:
Wasn't necessary because it will be generated automatically

