### PR TITLE
feat: Validate CNPJ in Supplier, install cpf_cnpj Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+# Validator to CPF and CNPJ
+gem 'cpf_cnpj', '~> 0.2.1'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    cpf_cnpj (0.2.1)
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.1)
@@ -239,6 +240,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  cpf_cnpj (~> 0.2.1)
   debug
   importmap-rails
   jbuilder

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -1,3 +1,16 @@
 class Supplier < ApplicationRecord
   has_one :account
+
+  has_many :parts, dependent: :destroy
+  validates :name, presence: true
+  validates :cnpj, presence: true, uniqueness: true
+
+  validate :cnpj, :validate_cnpj
+
+  private 
+
+  def validate_cnpj
+     errors.add(:cnpj, "invalid cnpj") unless CNPJ.valid?(cnpj)
+  end
+
 end


### PR DESCRIPTION
###Add Gem

Add gem 'cpf_cnpj' into the project.
In the file Gemfile:
```ruby
# Validator to CPF and CNPJ
gem 'cpf_cnpj', '~> 0.2.1'
``` 
### Runs bundle to install the Gem
`bundle`

###Add validates into the Supplier model including the callback validator 'validate_cnpj':

```ruby
class Supplier < ApplicationRecord
  has_one :account

  has_many :parts, dependent: :destroy
  validates :name, presence: true
  validates :cnpj, presence: true, uniqueness: true

  validate :cnpj, :validate_cnpj

  private 

  def validate_cnpj
     errors.add(:cnpj, "invalid cnpj") unless CNPJ.valid?(cnpj)
  end

end
``` 
