### PR TITLE
feat: Validate CPF in Author

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,3 +1,15 @@
 class Author < ApplicationRecord
   has_many :books, dependent: :destroy
+
+  validates :name, presence: true
+  validates :cpf, presence: true, uniqueness: true
+
+  validate :cpf, :validate_cpf
+
+  private
+
+  def validate_cpf
+    errors.add :cpf, "is invalid" unless CPF.valid?(cpf)
+  end
+  
 end


### PR DESCRIPTION
### Add Gem

The Gem 'cpf_cnpj' was added in the [Validate CNPJ in Supplier](https://github.com/vanderleipinto/preparation_mentorship/issues/27)


### Add validates into the Author model including the callback validator 'validate_cnpj':

In the file: app/models/author.rb

```ruby
class Author < ApplicationRecord
  has_many :books, dependent: :destroy

  validates :name, presence: true
  validates :cpf, presence: true, uniqueness: true

  validate :cpf, :validate_cpf

  private

  def validate_cpf
    errors.add :cpf, "is invalid" unless CPF.valid?(cpf)
  end
  
end

``` 

