### PR TITLE
feat: Calculate Verify digit in Account

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,3 +1,22 @@
-class Account < ApplicationRecord  
+class Account < ApplicationRecord
   belongs_to :supplier
+
+  validates :account_number, presence: true
+  validate :verify_digit, :calculate_verify_digit
+
+  def calculate_verify_digit
+    number = self.account_number
+    weight = [2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5]
+    sum = 0
+
+    number.to_s.reverse.chars.each_with_index do |value, index|
+      sum += value.to_i * weight[index % 12]
+    end
+      
+    rest = sum % 11
+    verify_digit = (rest < 2) ? 0 : (11 - rest)
+
+    self.verify_digit = verify_digit.to_s
+    verify_digit
+  end
 end


### PR DESCRIPTION
###Create a algorithm to calculate a verify digit.
The algorithm will be created in the model, so that when we create the object in the controller, we can use the method to insert the verify digit.
The logic to calculate de verify digit was found in the site [Secretaria da Fazenda de Pernambuco](https://www.sefaz.pe.gov.br/Servicos/sintegra/Paginas/calculo-do-digito-verificador.aspx)

In the file app/models/account.rb:

```ruby
class Account < ApplicationRecord
  belongs_to :supplier

  validates :account_number, presence: true
  validate :verify_digit, :calculate_verify_digit

  def calculate_verify_digit
    number = self.account_number
    weight = [2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5]
    sum = 0

    number.to_s.reverse.chars.each_with_index do |value, index|
      sum += value.to_i * weight[index % 12]
    end
      
    rest = sum % 11
    verify_digit = (rest < 2) ? 0 : (11 - rest)

    self.verify_digit = verify_digit.to_s
    verify_digit
  end
end

``` 