### PR TITLE
refactor: change field name to title in book

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -65,6 +65,6 @@ class BooksController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def book_params
-      params.require(:book).permit(:name, :description, :author_id, :isbn, assembly_ids: [])
+      params.require(:book).permit(:title, :description, :author_id, :isbn, assembly_ids: [])
     end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,7 +2,7 @@ class Book < ApplicationRecord
   belongs_to :author
   has_and_belongs_to_many :assemblies
 
-  validates :name, presence: true
+  validates :title, presence: true
   validate :isbn, :isbn_valid
 
   private

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id book %>">
   <p>
-    <strong>Name:</strong>
-    <%= book.name %>
+    <strong>Title:</strong>
+    <%= book.title %>
   </p>
 
   <p>

--- a/app/views/books/_book.json.jbuilder
+++ b/app/views/books/_book.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! book, :id, :name, :description, :author_id, :created_at, :updated_at
+json.extract! book, :id, :title, :description, :author_id, :created_at, :updated_at
 json.url book_url(book, format: :json)

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -12,8 +12,8 @@
   <% end %>
 
   <div>
-    <%= form.label :name, style: "display: block" %>
-    <%= form.text_field :name %>
+    <%= form.label :title, style: "display: block" %>
+    <%= form.text_field :title %>
   </div>
 
   <div>

--- a/db/migrate/20240214195336_rename_name_column_in_books.rb
+++ b/db/migrate/20240214195336_rename_name_column_in_books.rb
@@ -1,0 +1,5 @@
+class RenameNameColumnInBooks < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :books, :name, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_11_173135) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_14_195336) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "account_number"
     t.bigint "supplier_id", null: false
@@ -44,7 +44,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_11_173135) do
   end
 
   create_table "books", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
+    t.string "title"
     t.text "description"
     t.bigint "author_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
### Change the collum Books.name to Books.title
`rails generate migration RenameNameColumnInBooks`

Then change the migrate file:

```ruby
class RenameNameColumnInBooks < ActiveRecord::Migration[7.1]
  def change
    rename_column :books, :name, :title
  end
end

``` 

Change the files which have the references to name, such as:
app/views/books/_form.html.erb
app/views/books/_book.html.erb
app/views/books/_book.json.jbuilder
app/controllers/books_controller.rb
app/models/book.rb

### Runs migrate
`rails db:migrate`
