### PR TITLE
feat: Filter Assembly by name in Part

### DIFF
--- a/app/controllers/assemblies_controller.rb
+++ b/app/controllers/assemblies_controller.rb
@@ -3,7 +3,12 @@ class AssembliesController < ApplicationController
 
   # GET /assemblies or /assemblies.json
   def index
-    @assemblies = Assembly.all
+
+    if params[:search_assembly].present? || params[:search_part].present?
+      @assemblies = Assembly.joins(:parts).where("parts.name LIKE ? AND assemblies.name LIKE ?", "%#{params[:search_part]}%", "%#{params[:search_assembly]}%").distinct
+    else
+      @assemblies = Assembly.all
+    end    
   end
 
   # GET /assemblies/1 or /assemblies/1.json

--- a/app/views/assemblies/_assembly.html.erb
+++ b/app/views/assemblies/_assembly.html.erb
@@ -3,5 +3,19 @@
     <strong>Name:</strong>
     <%= assembly.name %>
   </p>
+  
+    <strong>Parts:</strong>
+    <%if assembly.parts.any?%>
+      <ul>
+        <% assembly.parts.each do |part| %>
+        <div>
+          <li><%=part.name%></li>
+        </div>
+        <%end%>
+      </ul>
+    </p>
+    <%else%>
+      <p>This assembly has no parts.</p>
+    <%end%>
 
 </div>

--- a/app/views/assemblies/_search_form.html.erb
+++ b/app/views/assemblies/_search_form.html.erb
@@ -1,0 +1,12 @@
+<div>
+  <%= form_tag(assemblies_path, method: :get) do %>
+  <label for="search_title">Name:</label>
+  <%= text_field_tag(:search_assembly) %> 
+  
+  <label for="search_title">Part:</label>
+  <%= text_field_tag(:search_part) %> 
+  
+
+    <%= submit_tag("Search Assembly(ies)") %>
+  <% end %>
+</div> 

--- a/app/views/assemblies/index.html.erb
+++ b/app/views/assemblies/index.html.erb
@@ -2,6 +2,8 @@
 
 <h1>Assemblies</h1>
 
+<%= render 'search_form' %>
+
 <div id="assemblies">
   <% @assemblies.each do |assembly| %>
     <%= render assembly %>


### PR DESCRIPTION
### Create a search form to find assemblies or insert parts field in the existing form.
In the file app/views/assemblies/_search_form.html.erb

```ruby
<div>
  <%= form_tag(assemblies_path, method: :get) do %>
  <label for="search_title">Name:</label>
  <%= text_field_tag(:search_assembly) %> 
  
  <label for="search_title">Part:</label>
  <%= text_field_tag(:search_part) %> 
  

    <%= submit_tag("Search Assembly(ies)") %>
  <% end %>
</div> 
``` 

### Render the form in the assembly index.
In the file app/views/assemblies/index.html.erb

```ruby
...
  <%= render 'search_form' %>
...
``` 

### Change the Controller to select the assemblies.
In the file app/controllers/assemblies_controller.rb

```ruby
# GET /assemblies or /assemblies.json
  def index

    if params[:search_assembly].present? || params[:search_part].present?
      @assemblies = Assembly.joins(:parts).where("parts.name LIKE ? AND assemblies.name LIKE ?", "%#{params[:search_part]}%", "%#{params[:search_assembly]}%").distinct
    else
      @assemblies = Assembly.all
    end    
  end

``` 