### PR TITLE
feat: Add field Name in Parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,16 @@ Validate
 CNPJ in Supplier
 ISBN in Book
 CPF in Author
+
+
+Release V0.4
+
+Battle 5 Report
+
+> Add
+- Value field in Part
+
+>Report
+- Author (with all the information) with his Books (with all the information) and the total number of books published
+- Supplier (with all information) with all authors (with all information) and books (with all information)
+- Book with the assembly (with all the information), with its parts (with all the information), the total number of parts and the total cost of the assembly.

--- a/app/controllers/parts_controller.rb
+++ b/app/controllers/parts_controller.rb
@@ -21,7 +21,11 @@ class PartsController < ApplicationController
 
   # POST /parts or /parts.json
   def create
-    @part = Part.new(part_params)
+    params = part_params
+    #Change the ',' into '.' in params[:value], otherwise the database would receive only the int number.
+    params[:value].sub!(",", ".")
+    
+    @part = Part.new(params)
 
     respond_to do |format|
       if @part.save
@@ -36,8 +40,11 @@ class PartsController < ApplicationController
 
   # PATCH/PUT /parts/1 or /parts/1.json
   def update
+    params = part_params
+    #Chancge the ',' into '.' in params[:value], otherwise the database would receive only the int number.
+    params[:value].sub!(",", ".")
     respond_to do |format|
-      if @part.update(part_params)
+      if @part.update(params)
         format.html { redirect_to part_url(@part), notice: "Part was successfully updated." }
         format.json { render :show, status: :ok, location: @part }
       else
@@ -65,6 +72,6 @@ class PartsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def part_params
-      params.require(:part).permit(:name, :supplier_id)
+      params.require(:part).permit(:name, :supplier_id, :value)
     end
 end

--- a/app/views/parts/_form.html.erb
+++ b/app/views/parts/_form.html.erb
@@ -16,6 +16,12 @@
     <%= form.text_field :name %>
   </div>
 
+
+  <div>
+    <%= form.label :value, style: "display: block" %>
+    <%= form.text_field :value %>
+  </div>
+
   <div>
     <%= form.label :supplier_id, style: "display: block" %>
     <%= form.collection_select :supplier_id, Supplier.all, :id, :name, prompt: 'Select Supplier'%>

--- a/app/views/parts/_part.html.erb
+++ b/app/views/parts/_part.html.erb
@@ -5,8 +5,13 @@
   </p>
 
   <p>
+    <strong>Value:</strong>
+    <%= part.value %>
+  </p>
+
+  <p>
     <strong>Supplier:</strong>
-    <%= part.supplier_id %>
+    <%= part.supplier.name %>
   </p>
 
 </div>

--- a/db/migrate/20240220124257_add_value_to_parts.rb
+++ b/db/migrate/20240220124257_add_value_to_parts.rb
@@ -1,0 +1,7 @@
+class AddValueToParts < ActiveRecord::Migration[7.1]
+  def change
+    
+    add_column :parts, :value, :decimal, precision: 8, scale: 2
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_14_195336) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_20_124257) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "account_number"
     t.bigint "supplier_id", null: false
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_14_195336) do
     t.bigint "supplier_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "value", precision: 8, scale: 2
     t.index ["supplier_id"], name: "index_parts_on_supplier_id"
   end
 


### PR DESCRIPTION
### Create collumn value into Parts.

`rails generate migration AddValueToParts value:decimal`

### Change the created migrate file db/migrate/*******_add_value_to_parts.rb

```ruby
class AddValueToParts < ActiveRecord::Migration[7.1]
  def change
    add_column :parts, :value, :decimal, precision: 8, scale: 2
  end
end

``` 
### Migrate
`rails db:migrate`

### Insert value field in the parts form:
In the file app/views/parts/_form.html.erb

```ruby
...
  <div>
    <%= form.label :value, style: "display: block" %>
    <%= form.text_field :value %>
  </div>
...
``` 

### Allow the controller to receive CNPJ param.
In the file app/controllers/parts_controller.rb add :value to permited params.
```ruby
...
    # Only allow a list of trusted parameters through.
    def part_params
      params.require(:part).permit(:name, :supplier_id, :value)
    end
...
``` 
___Also in the controller change the format of value from ##,## to ##.##___
It means the comma will be replaced by dot.

```ruby
  ...
# POST /parts or /parts.json
  def create
    params = part_params
    #Change the ',' into '.' in params[:value], otherwise the database would receive only the int number.
    params[:value].sub!(",", ".")
    
    @part = Part.new(params)
...
``` 
The same changes in the update action:

```ruby
  ...
# PATCH/PUT /parts/1 or /parts/1.json
  def update
    params = part_params
    #Chancge the ',' into '.' in params[:value], otherwise the database would receive only the int number.
    params[:value].sub!(",", ".")
    respond_to do |format|
      if @part.update(params)
...
``` 
### Change the view to show the price.
In the file app/views/parts/_part.html.erb
```ruby
...
  <p>
    <strong>Value:</strong>
    <%= part.value %>
  </p>

...
``` 