### PR TITLE
fix: supplier report didn't show book's author

### DIFF
--- a/app/views/suppliers/report.html.erb
+++ b/app/views/suppliers/report.html.erb
@@ -50,15 +50,16 @@
           
           <td>
             <ul>
-              
-              <% if @books.any? %>
-                <% @books.each do |book| %>
-                  <li><%= book.title %></li>
-                <% end %>                
+              <% books = Book.joins(assemblies: :parts).where(parts: { id: part.id }).distinct %>
+              <% if books.any? %>
+                <% books.each do |book| %>
+                  <% author = book.author %>
+                  <li><%= "#{book.title} (by #{author.name})" %></li>
+                <% end %>
               <% else %>
-                <li> <em>No books</em> </li>
+                <li><em>No books</em></li>
               <% end %>
-              </ul>
+            </ul>
           </td>
           <td>
             <ul>


### PR DESCRIPTION
To ensure that the books displayed are associated with the correct authors, it was necessary to adjust the logic in the books display section. I was trying to display the books associated with the vendor, but it's not taking into account the author associated with each book.